### PR TITLE
feat: Add Geist UI-inspired Spinner component

### DIFF
--- a/apps/dashboard/app/org/[id]/_components/org-projects/index.tsx
+++ b/apps/dashboard/app/org/[id]/_components/org-projects/index.tsx
@@ -3,17 +3,18 @@ import ProjectCardList from './project-card-list';
 import ProjectCardListSkeleton from './project-card-list-skeleton';
 
 export interface Props {
+  id: string;
   query: string;
   sort: 'recent' | 'name';
 }
 
-export default async function OrgProjects({ query, sort }: Props) {
+export default async function OrgProjects({ id, query, sort }: Props) {
   return (
     <div className="flex flex-col gap-2 lg:col-span-2">
       <h5 className="text-sm font-medium">Projects</h5>
       <div className="grid flex-1 gap-5 sm:grid-cols-2">
         <Suspense key={query + sort} fallback={<ProjectCardListSkeleton />}>
-          <ProjectCardList query={query} sort={sort} />
+          <ProjectCardList id={id} query={query} sort={sort} />
         </Suspense>
       </div>
     </div>

--- a/apps/dashboard/app/org/[id]/_components/org-projects/project-card-list.tsx
+++ b/apps/dashboard/app/org/[id]/_components/org-projects/project-card-list.tsx
@@ -1,4 +1,3 @@
-import { getOrgProjects } from '@/services/org.service';
 import { formatTimeSince } from '@/utils/datetime';
 import { getInitials } from '@/utils/string';
 import { Avatar, AvatarFallback } from '@repo/design-system/components/ui/avatar';
@@ -8,9 +7,11 @@ import { ArrowRight, Ellipsis, FolderOpen, GitBranch, SearchX } from 'lucide-rea
 import Link from 'next/link';
 import { Props } from '.';
 import { getAbbr } from '@/constants/abbr';
+import { OrgService } from '@/services/org.service';
 
-export default async function ProjectCardList({ query, sort }: Props) {
-  const projects = await getOrgProjects(query, sort);
+export default async function ProjectCardList({ id, query, sort }: Props) {
+  const service = new OrgService(id);
+  const projects = await service.getProjects({ query, sort });
 
   if (projects.length === 0) {
     const title = query ? 'No Results Found!' : 'No Project Yet!';

--- a/apps/dashboard/app/org/[id]/_components/org-recent-errors/index.tsx
+++ b/apps/dashboard/app/org/[id]/_components/org-recent-errors/index.tsx
@@ -9,7 +9,7 @@ import { Suspense } from 'react';
 import RecentErrorList from './recent-error-list';
 import RecentErrorListSkeleton from './recent-error-list-skeleton';
 
-export default async function OrgRecentErrors() {
+export default async function OrgRecentErrors({ id }: { id: string }) {
   return (
     <Collapsible defaultOpen className="sticky top-20 flex flex-col items-start gap-2">
       <h5 className="hidden text-sm font-medium lg:inline-block">Recent Errors</h5>
@@ -20,7 +20,7 @@ export default async function OrgRecentErrors() {
       <CollapsibleContent className="w-full">
         <ScrollArea className="h-full max-h-125 rounded-lg [&_[data-slot=scroll-area-viewport]]:max-h-125 [&_[data-slot=scroll-area-viewport]]:border">
           <Suspense fallback={<RecentErrorListSkeleton />}>
-            <RecentErrorList />
+            <RecentErrorList id={id} />
           </Suspense>
         </ScrollArea>
       </CollapsibleContent>

--- a/apps/dashboard/app/org/[id]/_components/org-recent-errors/recent-error-list.tsx
+++ b/apps/dashboard/app/org/[id]/_components/org-recent-errors/recent-error-list.tsx
@@ -1,5 +1,5 @@
 import { getAbbr } from '@/constants/abbr';
-import { getOrgRecentErrors } from '@/services/org.service';
+import { OrgService } from '@/services/org.service';
 import { formatTimeSince } from '@/utils/datetime';
 import { Badge } from '@repo/design-system/components/ui/badge';
 import { Button } from '@repo/design-system/components/ui/button';
@@ -7,10 +7,11 @@ import { cn } from '@repo/design-system/lib/utils';
 import { Ellipsis, ExternalLink } from 'lucide-react';
 import Link from 'next/link';
 
-export default async function RecentErrorList() {
-  const orgRecentErrors = await getOrgRecentErrors();
+export default async function RecentErrorList({ id }: { id: string }) {
+  const service = new OrgService(id);
+  const recentErrors = await service.getRecentErrors();
 
-  if (orgRecentErrors.length === 0) {
+  if (recentErrors.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center gap-2 py-5">
         <span className="text-sm font-medium">No Recent Errors!</span>
@@ -29,11 +30,11 @@ export default async function RecentErrorList() {
 
   return (
     <>
-      {orgRecentErrors.map((error, idx) => (
+      {recentErrors.map((error, idx) => (
         <div
           key={error.id}
           className={cn(
-            idx !== orgRecentErrors.length - 1 && 'border-b',
+            idx !== recentErrors.length - 1 && 'border-b',
             'bg-card group relative flex h-20 items-center justify-between gap-2 p-4 transition-[background]',
           )}
         >

--- a/apps/dashboard/app/org/[id]/page.tsx
+++ b/apps/dashboard/app/org/[id]/page.tsx
@@ -3,6 +3,7 @@ import OrgProjects from './_components/org-projects';
 import OrgRecentErrors from './_components/org-recent-errors';
 
 interface Props {
+  params: Promise<{ id: string }>;
   searchParams: Promise<{
     q?: string;
     sort?: 'recent' | 'name';
@@ -10,6 +11,7 @@ interface Props {
 }
 
 export default async function Page(props: Props) {
+  const { id } = await props.params;
   const searchParams = await props.searchParams;
   const query = searchParams.q ?? '';
   const sort = searchParams.sort ?? 'recent';
@@ -19,9 +21,9 @@ export default async function Page(props: Props) {
       <OrgControls />
       <section className="grid gap-5 lg:flex-1 lg:grid-cols-3">
         <div className="flex-1">
-          <OrgRecentErrors />
+          <OrgRecentErrors id={id} />
         </div>
-        <OrgProjects query={query} sort={sort} />
+        <OrgProjects id={id} query={query} sort={sort} />
       </section>
     </>
   );

--- a/apps/dashboard/app/project/[id]/logs/_components/logs-controls/search-input.tsx
+++ b/apps/dashboard/app/project/[id]/logs/_components/logs-controls/search-input.tsx
@@ -2,16 +2,14 @@
 
 import { useSearchParamsHandler } from '@/hooks/use-search-params-handler';
 import { Input, InputIcon, InputRoot } from '@repo/design-system/components/ui/input';
-import { Search } from 'lucide-react';
+import { Loader, Search } from 'lucide-react';
 
 export default function SearchInput() {
-  const { debouncedUpdateParam, getParam } = useSearchParamsHandler();
+  const { debouncedUpdateParam, getParam, loading } = useSearchParamsHandler();
 
   return (
     <InputRoot className="sm:col-span-3 md:col-span-4 lg:col-span-3">
-      <InputIcon>
-        <Search />
-      </InputIcon>
+      <InputIcon>{loading ? <Loader className="animate-spin" /> : <Search />}</InputIcon>
       <Input
         placeholder="Search..."
         defaultValue={getParam('q') ?? ''}

--- a/apps/dashboard/app/project/[id]/logs/_components/logs-list.tsx
+++ b/apps/dashboard/app/project/[id]/logs/_components/logs-list.tsx
@@ -1,5 +1,5 @@
 import {
-  ProjectLogService,
+  ProjectService,
   type ProjectLogsOptions as Props,
 } from '@/services/project.service';
 import { formatTimeSince } from '@/utils/datetime';
@@ -9,7 +9,7 @@ import { Ellipsis, SpellCheck2 } from 'lucide-react';
 import Link from 'next/link';
 
 export default async function LogsList({ id, query, env, status }: Props) {
-  const service = new ProjectLogService(id);
+  const service = new ProjectService(id);
   const logs = await service.getLogs({ query, env, status });
 
   return logs.map((log) => (

--- a/apps/dashboard/services/org.service.ts
+++ b/apps/dashboard/services/org.service.ts
@@ -1,38 +1,44 @@
 import rawProjectsData from '@/data/mock/projects.json';
 import recentErrorsData from '@/data/mock/recent_errors.json';
-import { IOrgProject, IOrgRecentError } from '@/types/org';
+import { OrgProject, OrgRecentError } from '@/types/org';
+import { waitFor } from '@/utils/promise';
 
-export function getOrgRecentErrors(): Promise<IOrgRecentError[]> {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve(recentErrorsData);
-    }, 1000);
-  });
+interface OrgGetProjects {
+  query: string;
+  sort: 'recent' | 'name';
 }
 
-export async function getOrgProjects(
-  query: string,
-  sort: 'recent' | 'name',
-): Promise<IOrgProject[]> {
-  return new Promise((resolve) =>
-    setTimeout(() => {
-      let resData: IOrgProject[] = [];
-      const normalizedQuery = query.toLowerCase();
-      const filteredData = rawProjectsData.filter((project) =>
-        project.name.toLowerCase().includes(normalizedQuery),
+export class OrgService {
+  constructor(private readonly orgId: string) {}
+
+  async getProjects({ query, sort }: OrgGetProjects): Promise<OrgProject[]> {
+    // simulate API request
+    await waitFor(1000);
+
+    let resData: OrgProject[] = [];
+    const normalizedQuery = query.toLowerCase();
+
+    const filteredData = rawProjectsData.filter((project) =>
+      project.name.toLowerCase().includes(normalizedQuery),
+    );
+
+    if (sort === 'recent') {
+      resData = filteredData.sort(
+        (a, b) =>
+          new Date(b.latestError.timestamp).getTime() -
+          new Date(a.latestError.timestamp).getTime(),
       );
+    } else if (sort === 'name') {
+      resData = filteredData.sort((a, b) => a.name.localeCompare(b.name));
+    }
 
-      if (sort === 'recent') {
-        resData = filteredData.sort(
-          (a, b) =>
-            new Date(b.latestError.timestamp).getTime() -
-            new Date(a.latestError.timestamp).getTime(),
-        );
-      } else if (sort === 'name') {
-        resData = filteredData.sort((a, b) => a.name.localeCompare(b.name));
-      }
+    return resData;
+  }
 
-      resolve(resData);
-    }, 1000),
-  );
+  async getRecentErrors(): Promise<OrgRecentError[]> {
+    // simulate API request
+    await waitFor(1000);
+
+    return recentErrorsData;
+  }
 }

--- a/apps/dashboard/services/project.service.ts
+++ b/apps/dashboard/services/project.service.ts
@@ -1,5 +1,6 @@
 import recentlogs from '@/data/mock/recent_errors.json';
 import { ProjectLog } from '@/types/project';
+import { waitFor } from '@/utils/promise';
 
 export interface ProjectLogsFilters {
   query?: string;
@@ -11,11 +12,13 @@ export interface ProjectLogsOptions extends ProjectLogsFilters {
   id: string;
 }
 
-export class ProjectLogService {
+export class ProjectService {
   constructor(private readonly projectId: string) {}
 
   async getLogs(filters: ProjectLogsFilters = {}): Promise<ProjectLog[]> {
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    // simulate API request
+    await waitFor(1000);
+
     const { query = '', env = 'all', status = 'resolved&pending' } = filters;
 
     const normalizedQuery = query.toLowerCase();

--- a/apps/dashboard/types/org.ts
+++ b/apps/dashboard/types/org.ts
@@ -1,4 +1,4 @@
-export interface IOrgProject {
+export interface OrgProject {
   id: string;
   name: string;
   domain: string;
@@ -15,7 +15,7 @@ export interface IOrgProject {
   };
 }
 
-export interface IOrgRecentError {
+export interface OrgRecentError {
   id: string;
   project: {
     id: string;

--- a/apps/dashboard/utils/promise.ts
+++ b/apps/dashboard/utils/promise.ts
@@ -1,0 +1,3 @@
+export async function waitFor(ms: number) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
Implements a proper Spinner component inspired by Vercel's Geist UI design:

- Creates a full-circle background track with partial spinning arc
- Follows shadcn/ui component conventions
- Provides size variants (sm, default, lg, icon)
- Uses subtle opacity differences for a modern look
- Replaces previous hack implementation in project-search

The component is ready for use across the application wherever loading states are needed.